### PR TITLE
Refactor directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ The client is responsible for managing the game display and user interactions. I
 4. The server regularly sends the game state to the clients, and also listens to potential actions (change direction or drop wagon) from the clients to influence the game.
 5. The client receives the game state in the `network.py` and updates the agent's game state from the `handle_state_data()` method in `game_state.py`.
 6. This method then calls `update_agent()` (inherited by the `Agent` class from the `BaseAgent` class) to ask for a new direction the agent has to determine.
-7. The `update_agent()` method then calls the method `get_direction()` to dynamically calculate the next direction the train should take according to the game state (where are the other trains, the walls, the passengers, the delivery zones, etc.) and send it to the server (`self.network.send_direction_change(direction)`).
+7. The `update_agent()` method then calls the method `get_move()` to dynamically calculate the next direction the train should take according to the game state (where are the other trains, the walls, the passengers, the delivery zones, etc.) and send it to the server.
 8. The server updates the game state and the cycle continues.
 
 ### Agent class
@@ -144,20 +144,17 @@ or by direcly checking what is returned by the `to_dict()` method in each class.
 You must implement an agent that controls your train. The main method to implement in `client/agent.py` is:
 
 ```python
-def get_direction(self, game_width, game_height):
+def get_move(self):
     """
-    This method is regularly called by the client to get the next direction of the train.
+    This method is regularly called by the client to get the next move for the train.
     """
 ```
 
 - Your train exists in a 2D grid. You can tell your train to turn left, right, or continue going straight. Your code should live in [client/agent.py](/client/agent.py) and any additional files you might need. You can also instruct your train to drop
 wagons.
 
-#### Using the network to send actions
-
-The agent can also call the method `self.network.send_drop_wagon_request()` to send a request to the server to drop a wagon.
-The train will then get a 0.25sec *1.5 speed boost and will enter a 10sec boost cooldown during which the train will not be able to drop wagons. Calling this method will drop one wagon from the train (costing 1 point from the train's score).
-This method is not supposed to be called to deliver the passengers to the delivery zone as the delivery is automatic.
+- Your train can drop wagons. The train will then get a speed boost and enter a boost cooldown period, during which the trin
+cannot drop wagons. Remember, passengers are automiatcally dropped off in the delivery zone.
 
 ## Evaluation
 

--- a/client/agent.py
+++ b/client/agent.py
@@ -1,20 +1,21 @@
 import random
 from client.base_agent import BaseAgent
+from common.move import Move
 
 # Student scipers, will be automatically used to evaluate your code
 SCIPERS = ["000001", "000002", "000003"]
 
-BASE_DIRECTIONS = [
-    (0, -1),  # Up
-    (1, 0),  # Right
-    (0, 1),  # Down
-    (-1, 0),  # Left
-]
-
 
 class Agent(BaseAgent):
-    def get_direction(self):
+    def get_move(self):
         """
-        This method is regularly called by the client to get the next direction of the train.
+        Called regularly called to get the next move for your train. Implement
+        an algorithm to control your train here. You will be handing in this file.
+
+        For now, the code simply picks a random direction between UP, DOWN, LEFT, RIGHT
+
+        This method must return one of moves.MOVE
         """
-        return random.choice(BASE_DIRECTIONS)  # Replace this with your own logic
+
+        moves = [Move.UP, Move.DOWN, Move.LEFT, Move.RIGHT]
+        return random.choice(moves)

--- a/client/event_handler.py
+++ b/client/event_handler.py
@@ -5,6 +5,8 @@ Module for handling events for the I Like Trains client
 import pygame
 import logging
 
+from common.move import Move
+
 
 # Configure the logger
 logger = logging.getLogger("client.event_handler")
@@ -50,13 +52,13 @@ class EventHandler:
                 if self.control_mode == "manual":
                     # Change the train's direction based on the pressed keys
                     if event.key == pygame.K_UP:
-                        self.client.network.send_direction_change((0, -1))
+                        self.client.network.send_direction_change(Move.UP.value)
                     elif event.key == pygame.K_DOWN:
-                        self.client.network.send_direction_change((0, 1))
+                        self.client.network.send_direction_change(Move.DOWN.value)
                     elif event.key == pygame.K_LEFT:
-                        self.client.network.send_direction_change((-1, 0))
+                        self.client.network.send_direction_change(Move.LEFT.value)
                     elif event.key == pygame.K_RIGHT:
-                        self.client.network.send_direction_change((1, 0))
+                        self.client.network.send_direction_change(Move.RIGHT.value)
                     # key D drops a wagon
                     elif event.key == pygame.K_d:
                         self.client.network.send_drop_wagon_request()

--- a/client/renderer.py
+++ b/client/renderer.py
@@ -6,6 +6,8 @@ import pygame
 import logging
 import time
 
+from common.move import Move
+
 # Configure logger
 logger = logging.getLogger("client.renderer")
 
@@ -214,7 +216,7 @@ class Renderer:
             train_x += self.client.game_screen_padding
             train_y += self.client.game_screen_padding
             train_wagons = train_data.get("wagons", [])
-            train_direction = train_data.get("direction", (1, 0))
+            train_direction = train_data.get("direction", Move.RIGHT)
             train_color = train_data.get("color", (0, 255, 0))
             train_wagon_color = tuple(
                 min(c + 50, 255) for c in train_color

--- a/common/move.py
+++ b/common/move.py
@@ -1,0 +1,43 @@
+from enum import Enum
+
+
+class Move(Enum):
+    UP = (0, -1)
+    RIGHT = (1, 0)
+    DOWN = (0, 1)
+    LEFT = (-1, 0)
+    DROP = "drop"
+
+    def turn_left(move):
+        """
+        Helper function you can call on the class. E.g.
+        Move.turn_left(Move.UP)
+        """
+        match move:
+            case Move.UP:
+                return Move.LEFT
+            case Move.RIGHT:
+                return Move.UP
+            case Move.DOWN:
+                return Move.RIGHT
+            case Move.LEFT:
+                return Move.DOWN
+            case _:
+                return move
+
+    def turn_right(move):
+        """
+        Helper function you can call on the class. E.g.
+        Move.turn_right(Move.UP)
+        """
+        match move:
+            case Move.UP:
+                return Move.RIGHT
+            case Move.RIGHT:
+                return Move.DOWN
+            case Move.DOWN:
+                return Move.LEFT
+            case Move.LEFT:
+                return Move.UP
+            case _:
+                return move

--- a/server/server.py
+++ b/server/server.py
@@ -13,12 +13,6 @@ from server.ai_client import AIClient
 from server.room import Room, load_best_scores
 
 
-# Directions
-UP = (0, -1)
-DOWN = (0, 1)
-LEFT = (-1, 0)
-RIGHT = (1, 0)
-
 # List of names for AI-controlled clients
 AI_NAMES = [
     "Bot Adrian",

--- a/server/train.py
+++ b/server/train.py
@@ -4,6 +4,8 @@ Train class for the game "I Like Trains"
 
 import logging
 
+from common.move import Move
+
 # Configure logging
 logging.basicConfig(
     level=logging.DEBUG,
@@ -12,12 +14,6 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger("server.train")
-
-# Directions
-UP = (0, -1)
-DOWN = (0, 1)
-LEFT = (-1, 0)
-RIGHT = (1, 0)
 
 # Train settings
 # INITIAL_SPEED = 60  # Initial speed in pixels per second
@@ -34,9 +30,9 @@ class Train:
     def __init__(self, x, y, agent_name, color, handle_train_death, tick_rate):
         self.position = (x, y)
         self.wagons = []
-        self.new_direction = (1, 0)
-        self.direction = (1, 0)  # Starts right
-        self.previous_direction = (1, 0)
+        self.new_direction = Move.RIGHT.value
+        self.direction = Move.RIGHT.value
+        self.previous_direction = Move.RIGHT.value
         self.agent_name = agent_name
         self.alive = True
         self.score = 0
@@ -349,9 +345,9 @@ class Train:
     def reset(self):
         self.position = (-1, -1)  # Use an off-screen position instead of None
         self.wagons = []
-        self.direction = (1, 0)
-        self.new_direction = (1, 0)
-        self.previous_direction = (1, 0)
+        self.direction = Move.RIGHT.value
+        self.new_direction = Move.RIGHT.value
+        self.previous_direction = Move.RIGHT.value
         self._dirty = {
             "position": True,
             "wagons": True,


### PR DESCRIPTION
- Remove some code/constant duplication.
- Provide a nice Move enum, with helper methods to turn left and right.
- Make it easier for agents to drop wagon (by simply returning Move.DROP).
- Renames get_direction to get_move to better reflect that we can return a direction or drop a wagon.