### PR TITLE
Grading mode. Using tickrate instead of time in game

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -296,16 +296,6 @@ class Client:
 
         logger.info(f"Game lifetime set to {self.game_life_time} seconds")
 
-    def get_remaining_time(self):
-        """Calculate remaining game time in seconds"""
-        if not hasattr(self, "game_life_time") or not hasattr(self, "game_start_time"):
-            return None
-
-        elapsed = time.time() - self.game_start_time
-        remaining = max(0, self.game_life_time - elapsed)
-
-        return remaining
-
     def handle_server_disconnection(self):
         """Handle server disconnection gracefully"""
         logger.warning("Server disconnected, shutting down client...")

--- a/client/game_state.py
+++ b/client/game_state.py
@@ -93,6 +93,13 @@ class GameState:
             self.client.best_scores = data["best_scores"]
             if self.game_mode == GameMode.AGENT and self.client.agent is not None:
                 self.client.agent.best_scores = self.client.best_scores
+                
+        # Récupérer le temps restant s'il est présent dans les données
+        if "remaining_time" in data:
+            self.client.remaining_game_time = data["remaining_time"]
+            # logger.info(f"Remaining time updated: {self.client.remaining_game_time}")
+            # if self.game_mode == GameMode.AGENT and self.client.agent is not None:
+            #     self.client.agent.remaining_game_time = self.client.remaining_game_time
 
         # Update the agent's state
         if self.game_mode == GameMode.AGENT and self.client.agent is not None:

--- a/client/renderer.py
+++ b/client/renderer.py
@@ -600,7 +600,7 @@ class Renderer:
         # Draw remaining time below the leaderboard
         if hasattr(self.client, "remaining_game_time"):
             # Format time as mm:ss
-            remaining = max(0, self.client.remaining_game_time)
+            remaining = self.client.remaining_game_time
             minutes = int(remaining) // 60
             seconds = int(remaining) % 60
             time_text = f"Time remaining: {minutes:02d}:{seconds:02d}"

--- a/client/renderer.py
+++ b/client/renderer.py
@@ -10,6 +10,7 @@ from common.move import Move
 
 # Configure logger
 logger = logging.getLogger("client.renderer")
+logger.setLevel(logging.DEBUG)
 
 
 class Renderer:
@@ -597,14 +598,9 @@ class Renderer:
             y_offset += 25
 
         # Draw remaining time below the leaderboard
-        if hasattr(self.client, "game_start_time") and hasattr(
-            self.client, "game_life_time"
-        ):
-            # Calculate remaining time
-            elapsed = time.time() - self.client.game_start_time
-            remaining = max(0, self.client.game_life_time - elapsed)
-
+        if hasattr(self.client, "remaining_game_time"):
             # Format time as mm:ss
+            remaining = max(0, self.client.remaining_game_time)
             minutes = int(remaining) // 60
             seconds = int(remaining) % 60
             time_text = f"Time remaining: {minutes:02d}:{seconds:02d}"

--- a/common/server_config.py
+++ b/common/server_config.py
@@ -31,6 +31,7 @@ class ServerConfig(BaseModel):
     # Flag to enable the simulation mode for grading. 
     # In normal mode, we add all human players to the game first and then add bots if needed. 
     # In grading mode, we add all configured agents to the game.
+    # If grading_mode is enabled, tick_rate is set to 10000 to run as fast as possible.
     grading_mode: bool = False
 
     # Duration of each game.

--- a/common/server_config.py
+++ b/common/server_config.py
@@ -28,7 +28,9 @@ class ServerConfig(BaseModel):
     # useful for debugging purpose.
     tick_rate: int = 60
 
-    # Flag to enable the fast simulation mode for grading.
+    # Flag to enable the simulation mode for grading. 
+    # In normal mode, we add all human players to the game first and then add bots if needed. 
+    # In grading mode, we add all configured agents to the game.
     grading_mode: bool = False
 
     # Duration of each game.

--- a/common/server_config.py
+++ b/common/server_config.py
@@ -28,6 +28,9 @@ class ServerConfig(BaseModel):
     # useful for debugging purpose.
     tick_rate: int = 60
 
+    # Flag to enable the fast simulation mode for grading.
+    grading_mode: bool = False
+
     # Duration of each game.
     game_duration_seconds: int = 300  # 300 seconds == 5 minutes
 
@@ -50,4 +53,3 @@ class ServerConfig(BaseModel):
 
     # Local agents configuration, add or remove agents you want to evaluate as needed
     agents: list[AgentConfig] = []
-

--- a/server/ai_client.py
+++ b/server/ai_client.py
@@ -147,6 +147,7 @@ class AIClient:
         self.game_width = self.game.game_width
         self.game_height = self.game.game_height
         self.in_waiting_room = not self.game.game_started
+        self.remaining_game_time = self.game.last_remaining_time
 
     def update_cycle(self):
         """Execute a single update cycle without the loop - used in grading mode"""

--- a/server/ai_client.py
+++ b/server/ai_client.py
@@ -109,12 +109,15 @@ class AIClient:
 
         self.agent.delivery_zone = self.game.delivery_zone.to_dict()
 
-        # Start the AI thread
+        # Start the AI thread only if not in grading mode
         self.running = True
-        self.thread = threading.Thread(target=self.run)
-        self.thread.daemon = True
-        self.thread.start()
-        logger.info(f"AI client {nickname} started")
+        if not room.config.grading_mode:
+            self.thread = threading.Thread(target=self.run)
+            self.thread.daemon = True
+            self.thread.start()
+            logger.info(f"AI client {nickname} started")
+        else:
+            logger.info(f"AI client {nickname} initialized in grading mode (no thread)")
 
         self.update_state()
 
@@ -145,64 +148,56 @@ class AIClient:
         self.game_height = self.game.game_height
         self.in_waiting_room = not self.game.game_started
 
+    def update_cycle(self):
+        """Execute a single update cycle without the loop - used in grading mode"""
+        logger.debug(f"Updating AI client {self.nickname}")
+        # Update the client state from the game
+        self.update_state()
+
+        # Make sure the agent has access to the correct properties
+        self.agent.all_trains = self.all_trains
+        self.agent.passengers = self.passengers
+        self.agent.cell_size = self.cell_size
+        self.agent.game_width = self.game_width
+        self.agent.game_height = self.game_height
+        self.agent.delivery_zone = self.game.delivery_zone.to_dict()
+
+        # Update agent state only if train is alive and game contains train
+        if not self.is_dead and self.game.contains_train(self.nickname):
+            self.agent.update_agent()
+
+        # Add automatic respawn logic
+        if self.is_dead and self.waiting_for_respawn:
+            elapsed = time.time() - self.death_time
+            if elapsed >= self.respawn_cooldown:
+                if self.in_waiting_room:
+                    logger.debug(
+                        f"AI client {self.nickname} in waiting room, trying to start game"
+                    )
+                    # Start game if in waiting room
+                    if (
+                        not self.room.game_thread
+                        or not self.room.game_thread.is_alive()
+                    ):
+                        if self.room.get_player_count() >= self.room.nb_players_max:
+                            self.room.start_game()
+
+                logger.debug(f"AI client {self.nickname} trying to spawn")
+                cooldown = self.room.game.get_train_cooldown(self.nickname)
+                if cooldown <= 0:
+                    self.room.game.add_train(self.nickname)
+                    self.waiting_for_respawn = False
+                    self.is_dead = False
+                    logger.info(f"AI client {self.nickname} respawned")
+
     def run(self):
         """Main AI client loop"""
         while self.running and self.room.running:
-            # try:
-            # Update the client state from the game
-            self.update_state()
-
-            # Make sure the agent has access to the correct properties
-            self.agent.all_trains = self.all_trains
-            self.agent.passengers = self.passengers
-            self.agent.cell_size = self.cell_size
-            self.agent.game_width = self.game_width
-            self.agent.game_height = self.game_height
-
-            # Update agent state only if train is alive and game contains train
-            if not self.is_dead and self.game.contains_train(self.nickname):
-                self.agent.update_agent()
-
-            # Add automatic respawn logic
-            # logger.debug(f"Is dead: {self.is_dead}, waiting for respawn: {self.waiting_for_respawn}")
-            if (
-                self.is_dead
-                and self.waiting_for_respawn
-            ):
-                # logger.debug(f"AI client {self.nickname} waiting for respawn")
-                elapsed = time.time() - self.death_time
-                if elapsed >= self.respawn_cooldown:
-                    # logger.debug(
-                    #     f"AI client {self.nickname} respawn cooldown over, checking game state"
-                    # )
-                    if self.in_waiting_room:
-                        logger.debug(
-                            f"AI client {self.nickname} in waiting room, trying to start game"
-                        )
-                        # Start game if in waiting room
-                        if (
-                            not self.room.game_thread
-                            or not self.room.game_thread.is_alive()
-                        ):
-                            if self.room.get_player_count() >= self.room.nb_players_max:
-                                self.room.start_game()
-
-                    logger.debug(f"AI client {self.nickname} trying to spawn")
-                    cooldown = self.room.game.get_train_cooldown(self.nickname)
-                    if cooldown <= 0:
-                        self.room.game.add_train(self.nickname)
-                        self.waiting_for_respawn = False
-                        self.is_dead = False
-                        logger.info(f"AI client {self.nickname} respawned")
-
-            # else:
-            #     logger.debug(f"AI client {self.nickname} is alive, waiting for next update")
-
+            # Execute a single update cycle
+            self.update_cycle()
+            
             # Sleep to avoid high CPU usage
             time.sleep(0.1)
-            # except Exception as e:
-            #     logger.error(f"Error in AI client {self.nickname}: {e}")
-            #     time.sleep(0.5)
 
     def stop(self):
         """Stop the AI client"""

--- a/server/ai_client.py
+++ b/server/ai_client.py
@@ -109,14 +109,11 @@ class AIClient:
 
         self.agent.delivery_zone = self.game.delivery_zone.to_dict()
 
-        # Start the AI thread only if not in grading mode
         self.running = True
         self.thread = threading.Thread(target=self.run)
         self.thread.daemon = True
         self.thread.start()
         logger.info(f"AI client {nickname} started")
-        # else:
-        #     logger.info(f"AI client {nickname} initialized in grading mode (no thread)")
 
         self.update_state()
 

--- a/server/ai_client.py
+++ b/server/ai_client.py
@@ -150,7 +150,6 @@ class AIClient:
 
     def update_cycle(self):
         """Execute a single update cycle without the loop - used in grading mode"""
-        logger.debug(f"Updating AI client {self.nickname}")
         # Update the client state from the game
         self.update_state()
 

--- a/server/ai_client.py
+++ b/server/ai_client.py
@@ -111,7 +111,6 @@ class AIClient:
 
         # Start the AI thread only if not in grading mode
         self.running = True
-        # if not room.config.grading_mode:
         self.thread = threading.Thread(target=self.run)
         self.thread.daemon = True
         self.thread.start()

--- a/server/game.py
+++ b/server/game.py
@@ -274,7 +274,6 @@ class Game:
         """Remove a train and update game size"""
         if nickname in self.trains:
             # Register the death time
-            # In grading mode, use tick-based cooldown
             self.train_death_ticks[nickname] = self.current_tick
             
             # Calculate the expected respawn tick based on the standard tickrate
@@ -291,8 +290,7 @@ class Game:
             logger.debug(f"Expected respawn at tick {expected_respawn_tick} (after {adjusted_cooldown_ticks} ticks, {real_seconds:.2f}s real time)")
 
             # Clean up the last delivery time for this train
-            if nickname in self.last_delivery_ticks:
-                del self.last_delivery_ticks[nickname]
+            self.last_delivery_ticks.pop(nickname, None)
 
             # Notify the client of the cooldown
             self.send_cooldown_notification(
@@ -326,7 +324,6 @@ class Game:
 
     def get_train_cooldown(self, nickname):
         """Get remaining cooldown time for a train"""
-        # In grading mode, use tick-based cooldown
         if nickname in self.train_death_ticks:
             ticks_elapsed = self.current_tick - self.train_death_ticks[nickname]
             

--- a/server/game.py
+++ b/server/game.py
@@ -312,12 +312,7 @@ class Game:
                 client = self.ai_clients[nickname]
                 # Change the train's state
                 client.is_dead = True
-                # if self.config.grading_mode:
-                #     # In grading mode, track death by tick
                 client.death_tick = self.current_tick
-                # else:
-                #     # In normal mode, track death by time
-                #     client.death_time = time.time()
                 client.waiting_for_respawn = True
                 client.respawn_cooldown = self.config.respawn_cooldown_seconds
             return True
@@ -358,7 +353,9 @@ class Game:
         return nickname in self.trains
 
     def check_collisions(self):
-        for _, train in self.trains.items():
+        # Créer une copie du dictionnaire pour éviter de le modifier pendant l'itération
+        trains_copy = list(self.trains.items())
+        for _, train in trains_copy:
             train.update(
                 self.trains,
                 self.game_width,

--- a/server/game.py
+++ b/server/game.py
@@ -248,14 +248,7 @@ class Game:
         logger.debug(f"Adding train {nickname}")
         # Check the cooldown
         if nickname in self.dead_trains:
-            elapsed = time.time() - self.dead_trains[nickname]
-            if elapsed < self.config.respawn_cooldown_seconds:
-                logger.debug(
-                    f"Train {nickname} still in cooldown for {self.config.respawn_cooldown_seconds - elapsed:.1f}s"
-                )
-                return False
-            else:
-                del self.dead_trains[nickname]
+            del self.dead_trains[nickname]
 
         # Create the new train
         spawn_pos = self.get_safe_spawn_position()

--- a/server/game.py
+++ b/server/game.py
@@ -81,7 +81,6 @@ class Game:
         self.desired_passengers = 0
 
         self.lock = threading.Lock()
-        self.last_update = time.time()
 
         self.game_started = False  # Track if game has started
         self.last_delivery_ticks = {}  # {nickname: last_delivery_tick}

--- a/server/game.py
+++ b/server/game.py
@@ -76,6 +76,7 @@ class Game:
         self.current_tick = 0  # Current tick counter
         self.start_time_ticks = 0  # Start time in ticks
         self.start_time = None  # Track when the game starts
+        self.last_remaining_time = None  # Track the last remaining time sent to clients
 
         self.desired_passengers = 0
 
@@ -145,11 +146,6 @@ class Game:
             self._dirty["best_scores"] = False
 
         return state
-
-    def run(self):
-        while self.running:
-            self.update()
-            time.sleep(1 / self.config.tick_rate)
 
     def is_position_safe(self, x, y):
         """Check if a position is safe for spawning"""
@@ -286,13 +282,13 @@ class Game:
         """Remove a train and update game size"""
         if nickname in self.trains:
             # Register the death time
-            if self.config.grading_mode:
-                # In grading mode, use tick-based cooldown
-                self.train_death_ticks[nickname] = self.current_tick
-                logger.debug(f"Train {nickname} died at tick {self.current_tick}, reason: {death_reason}")
-            else:
-                # In normal mode, use time-based cooldown
-                self.dead_trains[nickname] = time.time()
+            # if self.config.grading_mode:
+            # In grading mode, use tick-based cooldown
+            self.train_death_ticks[nickname] = self.current_tick
+            logger.debug(f"Train {nickname} died at tick {self.current_tick}, reason: {death_reason}")
+            # else:
+            #     # In normal mode, use time-based cooldown
+            #     self.dead_trains[nickname] = time.time()
 
             # Clean up the last delivery time for this train
             if nickname in self.last_delivery_times:
@@ -308,12 +304,12 @@ class Game:
                 client = self.ai_clients[nickname]
                 # Change the train's state
                 client.is_dead = True
-                if self.config.grading_mode:
-                    # In grading mode, track death by tick
-                    client.death_tick = self.current_tick
-                else:
-                    # In normal mode, track death by time
-                    client.death_time = time.time()
+                # if self.config.grading_mode:
+                #     # In grading mode, track death by tick
+                client.death_tick = self.current_tick
+                # else:
+                #     # In normal mode, track death by time
+                #     client.death_time = time.time()
                 client.waiting_for_respawn = True
                 client.respawn_cooldown = self.config.respawn_cooldown_seconds
             return True

--- a/server/game.py
+++ b/server/game.py
@@ -277,7 +277,7 @@ class Game:
             self.train_death_ticks[nickname] = self.current_tick
             
             # Calculate the expected respawn tick based on the standard tickrate
-            standard_tickrate = 60.0  # Reference tickrate
+            standard_tickrate = self.config.tick_rate  # Reference tickrate
             tickrate_ratio = standard_tickrate / self.config.tick_rate
             
             # For tickrate < standard (e.g. 30), the ratio > 1, making cooldown longer in real time
@@ -328,7 +328,7 @@ class Game:
             ticks_elapsed = self.current_tick - self.train_death_ticks[nickname]
             
             # Calculate adjusted cooldown ticks
-            standard_tickrate = 60.0  # Reference tickrate
+            standard_tickrate = self.config.tick_rate  # Reference tickrate
             tickrate_ratio = standard_tickrate / self.config.tick_rate
             adjusted_cooldown_ticks = int(self.config.respawn_cooldown_seconds * self.config.tick_rate * tickrate_ratio)
             
@@ -385,7 +385,7 @@ class Game:
                         self.last_delivery_ticks[train.nickname] = self.current_tick
 
     def get_delivery_cooldown_ticks(self):
-        standard_tickrate = 60.0  # Reference tickrate
+        standard_tickrate = self.config.tick_rate  # Reference tickrate
         tickrate_ratio = standard_tickrate / self.config.tick_rate
         adjusted_cooldown_ticks = int(self.config.delivery_cooldown_seconds * self.config.tick_rate * tickrate_ratio)
         return adjusted_cooldown_ticks
@@ -404,7 +404,7 @@ class Game:
             death_ticks_to_check = self.train_death_ticks.copy()
             for nickname, death_tick in death_ticks_to_check.items():
                 # Calculate the respawn cooldown with adjustment for game speed
-                standard_tickrate = 60.0  # Reference tickrate
+                standard_tickrate = self.config.tick_rate  # Reference tickrate
                 tickrate_ratio = standard_tickrate / self.config.tick_rate
                 
                 # Calculate cooldown ticks with proper adjustment for game speed

--- a/server/room.py
+++ b/server/room.py
@@ -273,7 +273,7 @@ class Room:
             
             # Sleep if necessary to maintain the desired tick rate in real time
             # Skip sleep in grading mode to run as fast as possible
-            if not self.config.grading_mode and real_seconds_per_tick > 0:
+            if real_seconds_per_tick > 0:
                 time_to_sleep = max(0, real_seconds_per_tick - tick_processing_time)
                 if time_to_sleep > 0:
                     time.sleep(time_to_sleep)

--- a/server/room.py
+++ b/server/room.py
@@ -133,7 +133,7 @@ class Room:
             except Exception as e:
                 logger.error(f"Error sending start success to client: {e}")
         
-        # In grading mode, we run the simulation directly in this thread
+        # In grading mode, we add all configured agents to the game
         if self.config.grading_mode:
             logger.info("Starting game in grading mode")
             if len(self.config.agents) > 0:
@@ -150,7 +150,7 @@ class Room:
             else:
                 logger.warning("No agents configured in config.json for grading mode")
         else:
-            # In normal mode, we start the game thread
+            # In normal mode, we add all human players to the game first and then add bots if needed
             logger.info("Starting game in normal mode")
             
             self.add_all_trains()

--- a/server/room.py
+++ b/server/room.py
@@ -185,7 +185,7 @@ class Room:
     def run_game(self):
         """Run the game in grading mode - directly in the room thread without using broadcast_game_state"""
         # Define the standard tick rate (for reference)
-        standard_tickrate = 60.0
+        standard_tickrate = self.config.tick_rate
         
         # Calculate total number of updates based on the standard tickrate
         # This ensures that game duration is consistent regardless of the configured tickrate
@@ -200,12 +200,16 @@ class Room:
         # Calculate how much real time should pass per tick (in seconds)
         # For higher tickrates, we want to process ticks faster (less real time per tick)
         # For lower tickrates, we want to process ticks slower (more real time per tick)
-        real_seconds_per_tick = 1.0 / self.config.tick_rate
+        if self.config.grading_mode:
+            tick_rate = 1000
+        else:
+            tick_rate = self.config.tick_rate
+        real_seconds_per_tick = 1.0 / tick_rate
         
         # Log the timing information
-        if self.config.tick_rate == standard_tickrate:
+        if tick_rate == standard_tickrate:
             speed_description = "normal speed"
-        elif self.config.tick_rate > standard_tickrate:
+        elif tick_rate > standard_tickrate:
             speed_description = f"{self.config.tick_rate/standard_tickrate:.1f}x faster than normal"
         else:
             speed_description = f"{standard_tickrate/self.config.tick_rate:.1f}x slower than normal"
@@ -230,7 +234,8 @@ class Room:
             
             # Update game time - this is completely independent of real time
             # Each tick represents a fixed amount of game time
-            game_time_elapsed += game_seconds_per_tick                
+            game_time_elapsed += game_seconds_per_tick
+            logger.debug(f"Game time elapsed: {game_time_elapsed:.2f}s")
 
             # Update game state
             self.game.update()

--- a/server/room.py
+++ b/server/room.py
@@ -66,13 +66,14 @@ class Room:
         self.client_game_modes = {}  # {addr: game_mode}
         self.game_thread = None
 
-        self.waiting_room_thread = None
         self.game_over = False  # Track if the game is over
         self.room_creation_time = time.time()  # Track when the room was created
         self.first_client_join_time = None  # Track when the first client joins
         self.stop_waiting_room = False  # Flag to stop the waiting room thread - Initialized BEFORE thread start
 
-        self.broadcast_waiting_room()
+        self.waiting_room_thread = threading.Thread(target=self.broadcast_waiting_room)
+        self.waiting_room_thread.daemon = True
+        self.waiting_room_thread.start()
 
         self.tick_counter = 0  # Track the number of ticks since game start
 

--- a/server/room.py
+++ b/server/room.py
@@ -200,12 +200,7 @@ class Room:
         # Calculate how much real time should pass per tick (in seconds)
         # For higher tickrates, we want to process ticks faster (less real time per tick)
         # For lower tickrates, we want to process ticks slower (more real time per tick)
-        if self.config.grading_mode:
-            # In grading mode, run as fast as possible
-            real_seconds_per_tick = 0
-        else:
-            # In normal mode, scale the real time per tick based on the tickrate
-            real_seconds_per_tick = 1.0 / self.config.tick_rate
+        real_seconds_per_tick = 1.0 / self.config.tick_rate
         
         # Log the timing information
         if self.config.tick_rate == standard_tickrate:
@@ -242,7 +237,6 @@ class Room:
             
             # Calculate remaining game time
             remaining_game_time = self.config.game_duration_seconds - game_time_elapsed
-            
             
             # Prepare the game state to send to clients
             state = self.game.get_state()
@@ -284,9 +278,6 @@ class Room:
                 if time_to_sleep > 0:
                     time.sleep(time_to_sleep)
 
-            # log remaining time
-            logger.info(f"Remaining time: {remaining_game_time:.2f} seconds")
-        
         # Game has finished
         end_time = time.time()
         total_real_time = end_time - game_start_time
@@ -675,7 +666,6 @@ class Room:
                         # Add remaining time to state data only if it has changed significantly (rounded to nearest second)
                         remaining_seconds = self.config.game_duration_seconds - (self.tick_counter / self.config.tick_rate)
                         current_remaining_time_rounded = round(remaining_seconds)
-                        logger.debug(f"Remaining time: {remaining_seconds}, Last remaining time: {self.game.last_remaining_time}")
                         if self.game.last_remaining_time is None or current_remaining_time_rounded != round(self.game.last_remaining_time):
                             logger.debug(f"Remaining time changed: {remaining_seconds}")
                             state["remaining_time"] = remaining_seconds

--- a/server/room.py
+++ b/server/room.py
@@ -118,13 +118,22 @@ class Room:
             if self.config.grading_mode:
                 logger.info(f"Starting game in grading mode for room {self.id}")
                 
-                # In grading mode, make sure we have at least one bot
-                if len(self.ai_clients) == 0 and len(self.config.agents) > 0:
-                    logger.info("No AI clients found, adding one for grading mode")
-                    agent = self.config.agents[0]
-                    ai_nickname = self.get_available_ai_name(agent)
-                    ai_agent_file_name = agent.agent_file_name
-                    self.add_ai(ai_nickname=ai_nickname, ai_agent_file_name=ai_agent_file_name)
+                # In grading mode, make sure we add all configured bots
+                if len(self.config.agents) > 0:
+                    logger.info(f"Adding {len(self.config.agents)} AI clients for grading mode")
+                    
+                    # Clear any existing AI clients first to avoid duplicates
+                    self.ai_clients = {}
+                    self.game.ai_clients = {}
+                    
+                    # Add all configured agents
+                    for agent in self.config.agents:
+                        ai_nickname = self.get_available_ai_name(agent)
+                        ai_agent_file_name = agent.agent_file_name
+                        logger.info(f"Adding AI client {ai_nickname} with agent {ai_agent_file_name}")
+                        self.add_ai(ai_nickname=ai_nickname, ai_agent_file_name=ai_agent_file_name)
+                else:
+                    logger.warning("No agents configured in config.json for grading mode")
                 
                 # Log AI clients before running
                 logger.info(f"AI clients before running grading mode: {self.ai_clients.keys()}")

--- a/server/room.py
+++ b/server/room.py
@@ -288,6 +288,11 @@ class Room:
         logger.info(f"Ticks per second: {self.tick_counter/total_real_time:.1f}")
         logger.info(f"Final scores: {self.game.best_scores}")
 
+        # Log how many times the trains moved
+        for train in self.game.trains.values():
+            logger.info(f"Train {train.nickname} moved {train.moved_count} times")
+            logger.info(f"Train {train.nickname} updated {train.update_count} times\n")
+
         logger.info(f"Game ending after {self.tick_counter} ticks, game time: {game_time_elapsed:.2f}s")
         self.end_game()
 

--- a/server/server.py
+++ b/server/server.py
@@ -637,9 +637,18 @@ class Server:
                         remaining_cooldown = 0
                         
                         if room.game.trains[nickname].boost_cooldown_active:
-                            current_time = time.time()
-                            elapsed_time = current_time - room.game.trains[nickname].start_cooldown_time
-                            remaining_cooldown = max(0, BOOST_COOLDOWN_DURATION - elapsed_time)
+                            # Use tick-based cooldown calculation
+                            current_tick = room.game.trains[nickname].move_timer
+                            ticks_elapsed = current_tick - room.game.trains[nickname].start_cooldown_tick
+                            
+                            # Convert duration to ticks using the same approach as in train.py
+                            standard_tickrate = 60.0  # Reference tickrate
+                            tickrate_ratio = standard_tickrate / room.game.trains[nickname].tick_rate
+                            required_ticks = int(BOOST_COOLDOWN_DURATION * room.game.trains[nickname].tick_rate * tickrate_ratio)
+                            
+                            remaining_ticks = max(0, required_ticks - ticks_elapsed)
+                            # Convert remaining ticks to seconds for user-friendly message
+                            remaining_cooldown = remaining_ticks / room.game.trains[nickname].tick_rate
                             message = f"Cannot drop wagon (cooldown active for {remaining_cooldown:.1f} more seconds)"
                         
                         # Notify the client that the drop_wagon action failed

--- a/server/server.py
+++ b/server/server.py
@@ -60,9 +60,14 @@ class Server:
     def __init__(self, config: Config):
         self.config = config.server
 
+        # Set extremely high tick_rate if grading_mode is enabled
+        if self.config.grading_mode:
+            logger.info("Grading mode detected. Setting tick_rate to 10000")
+            self.config.tick_rate = 10000
+
         # Verify that all agent files exist before proceeding
         self.verify_agent_files(self.config)
-
+        
         self.rooms = {}  # {room_id: Room}
         self.lock = threading.Lock()
 

--- a/server/server.py
+++ b/server/server.py
@@ -62,8 +62,8 @@ class Server:
         
         # Set extremely high tick_rate if grading_mode is enabled
         if self.config.grading_mode:
-            logger.info("Grading mode detected. Setting tick_rate to 10000")
-            self.config.tick_rate = 10000
+            logger.info("Grading mode detected. Setting tick_rate to 1000")
+            self.config.tick_rate = 1000
 
         # Verify that all agent files exist before proceeding
         self.verify_agent_files(self.config)

--- a/server/server.py
+++ b/server/server.py
@@ -59,11 +59,6 @@ logger = setup_server_logger()
 class Server:
     def __init__(self, config: Config):
         self.config = config.server
-        
-        # Set extremely high tick_rate if grading_mode is enabled
-        if self.config.grading_mode:
-            logger.info("Grading mode detected. Setting tick_rate to 1000")
-            self.config.tick_rate = 1000
 
         # Verify that all agent files exist before proceeding
         self.verify_agent_files(self.config)
@@ -642,7 +637,7 @@ class Server:
                             ticks_elapsed = current_tick - room.game.trains[nickname].start_cooldown_tick
                             
                             # Convert duration to ticks using the same approach as in train.py
-                            standard_tickrate = 60.0  # Reference tickrate
+                            standard_tickrate = self.config.tick_rate  # Reference tickrate
                             tickrate_ratio = standard_tickrate / room.game.trains[nickname].tick_rate
                             required_ticks = int(BOOST_COOLDOWN_DURATION * room.game.trains[nickname].tick_rate * tickrate_ratio)
                             

--- a/server/train.py
+++ b/server/train.py
@@ -108,7 +108,7 @@ class Train:
             ticks_elapsed = current_tick - self.start_cooldown_tick
             
             # Convert duration to ticks
-            standard_tickrate = 60.0  # Reference tickrate
+            standard_tickrate = self.tick_rate  # Reference tickrate
             tickrate_ratio = standard_tickrate / self.tick_rate
             required_ticks = int((BOOST_COOLDOWN_DURATION + BOOST_DURATION) * self.tick_rate * tickrate_ratio)
             

--- a/server/train.py
+++ b/server/train.py
@@ -109,13 +109,14 @@ class Train:
                 self.boost_cooldown_active = False
                 self._dirty["boost_cooldown_active"] = True
                 
-        # Increment movement timer
+        # Increment movement timer - with fixed increment to ensure consistent speed across tickrates
         self.move_timer += 1
 
+        # Simple threshold based on speed only - independent of tickrate
+        move_threshold = 60 / self.speed
+        
         # Check if it's time to move
-        if (
-            self.move_timer >= 60/ self.speed
-        ):  # self.tick_rate ticks per second
+        if self.move_timer >= move_threshold:
             self.move_timer = 0
             self.set_direction(self.new_direction)
             self.move(trains, screen_width, screen_height, cell_size)
@@ -182,7 +183,6 @@ class Train:
 
     def move(self, trains, screen_width, screen_height, cell_size):
         """Regular interval movement"""
-        # logger.debug(f"Moving train {self.nickname} with speed {self.speed}")
         if not self.alive:
             return
 

--- a/server/train.py
+++ b/server/train.py
@@ -114,7 +114,7 @@ class Train:
 
         # Check if it's time to move
         if (
-            self.move_timer >= self.tick_rate / self.speed
+            self.move_timer >= 60 / self.speed
         ):  # self.tick_rate ticks per second
             self.move_timer = 0
             self.set_direction(self.new_direction)
@@ -182,6 +182,7 @@ class Train:
 
     def move(self, trains, screen_width, screen_height, cell_size):
         """Regular interval movement"""
+        # logger.debug(f"Moving train {self.nickname} with speed {self.speed}")
         if not self.alive:
             return
 

--- a/server/train.py
+++ b/server/train.py
@@ -114,7 +114,7 @@ class Train:
 
         # Check if it's time to move
         if (
-            self.move_timer >= 60 / self.speed
+            self.move_timer >= self.tick_rate / self.speed
         ):  # self.tick_rate ticks per second
             self.move_timer = 0
             self.set_direction(self.new_direction)

--- a/server/train.py
+++ b/server/train.py
@@ -114,7 +114,7 @@ class Train:
 
         # Check if it's time to move
         if (
-            self.move_timer >= self.tick_rate / self.speed
+            self.move_timer >= 60/ self.speed
         ):  # self.tick_rate ticks per second
             self.move_timer = 0
             self.set_direction(self.new_direction)

--- a/server/train.py
+++ b/server/train.py
@@ -3,7 +3,6 @@ Train class for the game "I Like Trains"
 """
 
 import logging
-import time
 
 from common.move import Move
 
@@ -64,7 +63,8 @@ class Train:
         self.speed_boost_active = False
         self.speed_boost_timer = 0
         self.boost_cooldown_active = False
-        self.start_cooldown_time = 0
+        self.start_cooldown_tick = 0
+        self.boost_cooldown_ticks = 0
         self.normal_speed = INITIAL_SPEED  # Store normal speed for after boost ends
 
     def get_position(self):
@@ -101,9 +101,15 @@ class Train:
 
         # Manage boost cooldown timer
         if self.boost_cooldown_active:
-            current_time = time.time()
-            elapsed_time = current_time - self.start_cooldown_time
-            if elapsed_time >= BOOST_COOLDOWN_DURATION + BOOST_DURATION:
+            current_tick = self.move_timer  # Using move_timer as our tick counter
+            ticks_elapsed = current_tick - self.start_cooldown_tick
+            
+            # Convert duration to ticks
+            standard_tickrate = 60.0  # Reference tickrate
+            tickrate_ratio = standard_tickrate / self.tick_rate
+            required_ticks = int((BOOST_COOLDOWN_DURATION + BOOST_DURATION) * self.tick_rate * tickrate_ratio)
+            
+            if ticks_elapsed >= required_ticks:
                 logger.debug(f"Resetting cooldown for train {self.nickname}")
                 # Reset cooldown
                 self.boost_cooldown_active = False
@@ -170,7 +176,7 @@ class Train:
             # Start cooldown
             logger.debug(f"Starting cooldown for train {self.nickname}")
             self.boost_cooldown_active = True
-            self.start_cooldown_time = time.time()
+            self.start_cooldown_tick = self.move_timer
             self._dirty["boost_cooldown_active"] = True
 
             return last_wagon_pos

--- a/server/train.py
+++ b/server/train.py
@@ -46,6 +46,8 @@ class Train:
         self.move_timer = 0
         self.speed = INITIAL_SPEED
         self.last_position = (x, y)
+        self.moved_count = 0
+        self.update_count = 0
 
         self.tick_rate = tick_rate
         # Dirty flags to track modifications
@@ -85,6 +87,7 @@ class Train:
 
     def update(self, trains, screen_width, screen_height, cell_size):
         """Update the train position"""
+        self.update_count += 1
         if not self.alive:
             return
 
@@ -126,6 +129,7 @@ class Train:
             self.move_timer = 0
             self.set_direction(self.new_direction)
             self.move(trains, screen_width, screen_height, cell_size)
+            self.moved_count += 1
 
     def add_wagons(self, nb_wagons=1):
         """Add wagons to the train"""


### PR DESCRIPTION
Full evaluation mode. 

Added flag "grading_mode" to enable the simulation mode for grading. 
  In normal mode, we add all human players to the game first and then add bots if needed. 
  In grading mode, we add all configured agents to the game.
  If grading_mode is enabled, tick_rate is set to 10000 to run as fast as possible.

Changed the elements based on time in room/game/ai_client/train, to use room's tickrate instead.
Fixing #172 #120 