### PR TITLE
Bot and agent get_move() are now synchronous

### DIFF
--- a/client/game_state.py
+++ b/client/game_state.py
@@ -117,8 +117,15 @@ class GameState:
             if self.client.agent.delivery_zone is None:
                 self.client.agent.delivery_zone = self.client.delivery_zone
 
-            # Update agent state only if train is alive
-            if not self.client.is_dead:
+            # Update agent state only if:
+            # 1. Train is alive
+            # 2. Client's nickname is in the train data
+            # 3. The train's position has been updated
+            train_updated = ("trains" in data and 
+                            self.client.nickname in data["trains"] and 
+                            "position" in data["trains"][self.client.nickname])
+                            
+            if not self.client.is_dead and train_updated:
                 self.client.agent.update_agent()
 
     def handle_leaderboard_data(self, data):

--- a/client/game_state.py
+++ b/client/game_state.py
@@ -116,17 +116,18 @@ class GameState:
                 self.client.agent.game_height = self.client.game_height
             if self.client.agent.delivery_zone is None:
                 self.client.agent.delivery_zone = self.client.delivery_zone
-
-            # Update agent state only if:
-            # 1. Train is alive
-            # 2. Client's nickname is in the train data
-            # 3. The train's position has been updated
-            train_updated = ("trains" in data and 
-                            self.client.nickname in data["trains"] and 
-                            "position" in data["trains"][self.client.nickname])
+            
+            # Check if the train is in the client's stored trains collection
+            train_exists = self.client.nickname in self.client.trains
                             
-            if not self.client.is_dead and train_updated:
+            if not self.client.is_dead and train_exists:
                 self.client.agent.update_agent()
+            else:
+                # Log why the train is not updated
+                if self.client.is_dead:
+                    logger.debug(f"Not updating agent for client {self.client.nickname}: train is dead")
+                else:
+                    logger.debug(f"Not updating agent for client {self.client.nickname}: train is not in the game trains")
 
     def handle_leaderboard_data(self, data):
         """Handle leaderboard data received from the server"""

--- a/server/ai_client.py
+++ b/server/ai_client.py
@@ -126,19 +126,18 @@ class AIClient:
 
         # Initialize collections if they don't exist yet
         if not hasattr(self.agent, "all_trains") or self.agent.all_trains is None:
-            logger.debug("Initializing all_trains")
             self.agent.all_trains = {}
-        if not hasattr(self.agent, "passengers"):
+        if not hasattr(self.agent, "passengers") or self.agent.passengers is None:
             self.agent.passengers = []
-        if not hasattr(self.agent, "delivery_zone"):
+        if not hasattr(self.agent, "delivery_zone") or self.agent.delivery_zone is None:
             self.agent.delivery_zone = []
-        if not hasattr(self.agent, "cell_size"):
+        if not hasattr(self.agent, "cell_size") or self.agent.cell_size is None:
             self.agent.cell_size = None
-        if not hasattr(self.agent, "game_width"):
+        if not hasattr(self.agent, "game_width") or self.agent.game_width is None:
             self.agent.game_width = None
-        if not hasattr(self.agent, "game_height"):
+        if not hasattr(self.agent, "game_height") or self.agent.game_height is None:
             self.agent.game_height = None
-        if not hasattr(self.agent, "best_scores"):
+        if not hasattr(self.agent, "best_scores") or self.agent.best_scores is None:
             self.agent.best_scores = []
 
         # Update trains if present in the state data

--- a/server/ai_client.py
+++ b/server/ai_client.py
@@ -111,94 +111,81 @@ class AIClient:
         self.agent.delivery_zone = self.game.delivery_zone.to_dict()
 
         self.running = True
-        self.thread = threading.Thread(target=self.run)
-        self.thread.daemon = True
-        self.thread.start()
         logger.info(f"AI client {nickname} started")
 
-        self.update_state()
-
-    def update_state(self):
+    def update_state(self, state_data):
         """Update the state from the game"""
         # Get the serialized state data from the game
-        state_data = self.game.get_state()
-        
-        # Simuler la sérialisation/désérialisation JSON pour garantir le même format de données
-        # que les clients normaux (conversion des tuples en listes, etc.)
         state_data_json = json.dumps(state_data)
         state_data = json.loads(state_data_json)
-        
-        # Initialize collections if they don't exist yet
-        if not hasattr(self, "all_trains") or self.all_trains is None:
-            self.all_trains = {}
-        if not hasattr(self, "passengers") or self.passengers is None:
-            self.passengers = []
-        if not hasattr(self, "delivery_zone") or self.delivery_zone is None:
-            self.delivery_zone = []
-        if not hasattr(self, "cell_size") or self.cell_size is None:
-            self.cell_size = None
-        if not hasattr(self, "game_width") or self.game_width is None:
-            self.game_width = None
-        if not hasattr(self, "game_height") or self.game_height is None:
-            self.game_height = None
-        if not hasattr(self, "best_scores") or self.best_scores is None:
-            self.best_scores = []
 
-        # Process the state data similar to GameState.handle_state_data
-        
+        # Extract the actual state data from the nested structure
+        if "type" in state_data and state_data["type"] == "state" and "data" in state_data:
+            # Extract data from the nested structure
+            state_data = state_data["data"]
+
+        # Initialize collections if they don't exist yet
+        if not hasattr(self.agent, "all_trains") or self.agent.all_trains is None:
+            logger.debug("Initializing all_trains")
+            self.agent.all_trains = {}
+        if not hasattr(self.agent, "passengers"):
+            self.agent.passengers = []
+        if not hasattr(self.agent, "delivery_zone"):
+            self.agent.delivery_zone = []
+        if not hasattr(self.agent, "cell_size"):
+            self.agent.cell_size = None
+        if not hasattr(self.agent, "game_width"):
+            self.agent.game_width = None
+        if not hasattr(self.agent, "game_height"):
+            self.agent.game_height = None
+        if not hasattr(self.agent, "best_scores"):
+            self.agent.best_scores = []
+
         # Update trains if present in the state data
         if "trains" in state_data:
+            # Update only the modified trains
             for nickname, train_data in state_data["trains"].items():
-                if nickname not in self.all_trains:
-                    self.all_trains[nickname] = {}
-                # Update the modified attributes
-                self.all_trains[nickname].update(train_data)
-        
+                # If the train doesn't exist yet in all_trains, create it
+                if nickname not in self.agent.all_trains:
+                    self.agent.all_trains[nickname] = {}
+                    
+                # Update the train data with the new values
+                for key, value in train_data.items():
+                    self.agent.all_trains[nickname][key] = value
+
         # Update passengers if present
         if "passengers" in state_data:
-            self.passengers = state_data["passengers"]
-        
+            self.agent.passengers = state_data["passengers"]
+
         # Update delivery zone if present
         if "delivery_zone" in state_data:
-            self.delivery_zone = state_data["delivery_zone"]
-        
+            self.agent.delivery_zone = state_data["delivery_zone"]
+
         # Update size if present
         if "size" in state_data:
-            self.game_width = state_data["size"]["game_width"]
-            self.game_height = state_data["size"]["game_height"]
-        
+            self.agent.game_width = state_data["size"]["game_width"]
+            self.agent.game_height = state_data["size"]["game_height"]
+
         # Update cell size if present
         if "cell_size" in state_data:
-            self.cell_size = state_data["cell_size"]
-        
+            self.agent.cell_size = state_data["cell_size"]
+
         # Update best scores if present
         if "best_scores" in state_data:
-            self.best_scores = state_data["best_scores"]
-            
+            self.agent.best_scores = state_data["best_scores"]
+
+        # Update remaining time if present
+        if "remaining_time" in state_data:
+            if not hasattr(self.agent, "remaining_time"):
+                self.agent.remaining_time = 0
+            self.agent.remaining_time = state_data["remaining_time"]
+
         # Update other properties
         self.in_waiting_room = not self.game.game_started
-        
-        # Make sure the agent has access to the correct properties
-        self.agent.all_trains = self.all_trains
-        self.agent.passengers = self.passengers
-        self.agent.cell_size = self.cell_size
-        self.agent.best_scores = self.best_scores
-        self.agent.game_width = self.game_width
-        self.agent.game_height = self.game_height
-        self.agent.delivery_zone = self.delivery_zone if hasattr(self, "delivery_zone") else self.game.delivery_zone.to_dict()
-        
+
         # Update agent state only if train is alive and game contains train
         if not self.is_dead and self.game.contains_train(self.nickname):
             self.agent.update_agent()
-
-    def run(self):
-        """Main AI client loop"""
-        while self.running and self.room.running:
-            # Execute a single update cycle
-            self.update_state()
-            
-            # Sleep to avoid high CPU usage
-            time.sleep(0.1)
 
     def stop(self):
         """Stop the AI client"""

--- a/server/ai_client.py
+++ b/server/ai_client.py
@@ -186,6 +186,12 @@ class AIClient:
         # Update agent state only if train is alive and game contains train
         if not self.is_dead and self.game.contains_train(self.nickname):
             self.agent.update_agent()
+        else:
+            # Log why the train is not updated
+            if self.is_dead:
+                logger.debug(f"Not updating agent for AI client {self.nickname}: train is dead")
+            else:
+                logger.debug(f"Not updating agent for AI client {self.nickname}: train is not in the game")
 
     def stop(self):
         """Stop the AI client"""

--- a/server/game.py
+++ b/server/game.py
@@ -484,8 +484,4 @@ class Game:
                             ai_client.waiting_for_respawn = False
                             ai_client.is_dead = False
                             logger.info(f"AI client {ai_name} respawned")
-
-                # Update agent state only if train is alive and game contains train
-                # else:
-                #     # Call the update_cycle method directly instead of updating manually
-                #     ai_client.update_state(self.to_dict())
+                            

--- a/server/game.py
+++ b/server/game.py
@@ -486,6 +486,6 @@ class Game:
                             logger.info(f"AI client {ai_name} respawned")
 
                 # Update agent state only if train is alive and game contains train
-                else:
-                    # Call the update_cycle method directly instead of updating manually
-                    ai_client.update_state()
+                # else:
+                #     # Call the update_cycle method directly instead of updating manually
+                #     ai_client.update_state(self.to_dict())

--- a/server/room.py
+++ b/server/room.py
@@ -99,10 +99,6 @@ class Room:
 
     def start_game(self):
         logger.debug("Starting game...")
-        # Start the state thread
-        self.state_thread = threading.Thread(target=self.broadcast_game_state)
-        self.state_thread.daemon = True
-        self.state_thread.start()
 
         # Stop the waiting room thread by setting the flag
         self.stop_waiting_room = True

--- a/server/room.py
+++ b/server/room.py
@@ -175,9 +175,6 @@ class Room:
             for ai_name, ai_client in self.game.ai_clients.items():
                 if ai_name not in self.game.trains:
                     logger.info(f"Adding train for AI client {ai_name}")
-
-                # Update agent state
-                ai_client.update_state(self.game.get_state())
                 
                 # Log train status
                 if ai_name in self.game.trains:

--- a/server/room.py
+++ b/server/room.py
@@ -177,7 +177,7 @@ class Room:
                     logger.info(f"Adding train for AI client {ai_name}")
 
                 # Update agent state
-                ai_client.update_state()
+                ai_client.update_state(self.game.get_state())
                 
                 # Log train status
                 if ai_name in self.game.trains:
@@ -262,6 +262,10 @@ class Room:
             state_data = {"type": "state", "data": state}
 
             if state:  # If data has been modified
+                # Update all AI clients
+                for ai_client in self.ai_clients.values():
+                    ai_client.update_state(state_data)
+                
                 # Send the state to all clients
                 state_json = json.dumps(state_data) + "\n"
                 for client_addr in list(self.clients.keys()):

--- a/server/room.py
+++ b/server/room.py
@@ -211,10 +211,10 @@ class Room:
         else:
             speed_description = f"{reference_tickrate/self.config.tick_rate:.1f}x slower than normal"
             
-        logger.debug(f"Game running at {speed_description} (tickrate: {self.config.tick_rate}).")
-        logger.debug(f"Acceleration in comparison to reference tickrate: {self.config.tick_rate / reference_tickrate:.2f}")
-        logger.debug(f"Game seconds per tick: {game_seconds_per_tick:.4f}s")
-        logger.debug(f"Real seconds per tick: {real_seconds_per_tick*1000:.2f}ms")
+        logger.info(f"Game running at {speed_description} (tickrate: {self.config.tick_rate}).")
+        logger.info(f"Acceleration in comparison to reference tickrate: {self.config.tick_rate / reference_tickrate:.2f}")
+        logger.info(f"Game seconds per tick: {game_seconds_per_tick:.4f}s")
+        logger.info(f"Real seconds per tick: {real_seconds_per_tick*1000:.2f}ms")
         
         # Initialize game time to zero
         game_time_elapsed = 0.0

--- a/server/train.py
+++ b/server/train.py
@@ -47,7 +47,6 @@ class Train:
         self.move_timer = 0
         self.speed = INITIAL_SPEED
         self.last_position = (x, y)
-        self.moved_count = 0
 
         self.tick_rate = tick_rate
         self.reference_tick_rate = reference_tick_rate
@@ -202,7 +201,7 @@ class Train:
         """Regular interval movement"""
         if not self.alive:
             return
-
+        
         # Save the last position before moving
         if isinstance(self.position, tuple) and len(self.position) == 2:
             self.last_position = self.position


### PR DESCRIPTION
Updated the way the data is transmitted to agent and bot.
Fixed asynchronous calls to get_move() for agent (if its nickname is not in the received data).
Fixed the way elapsed_real_time is calculated.
Removed thread "broadcast_game_state".

After running for 30 seconds:
2025-05-08 13:50:59,098 - root - DEBUG - Update count for Adrien bot: 316 
2025-05-08 13:50:59,098 - root - DEBUG - Update count for Adrien agent: 316