### PR TITLE
Manage agent and client in different threads

### DIFF
--- a/client/agent_thread.py
+++ b/client/agent_thread.py
@@ -29,37 +29,31 @@ class AgentThread(threading.Thread):
                 
                 # Calculate the appropriate timing based on train speed
                 if len(self.client.trains) > 0 and self.client.nickname in self.client.trains:
-                    # Use the same formula as in GameState.handle_state_data
-                    from client.game_state import INITIAL_SPEED, SPEED_DECREMENT_COEFFICIENT
-                    train_speed = INITIAL_SPEED * SPEED_DECREMENT_COEFFICIENT ** len(self.client.trains[self.client.nickname]["wagons"])
-                    theoretical_time = 1.0 / train_speed
-                    
-                    # Check if agent is taking too long to respond
-                    current_time = time.time()
-                    if self.client.last_update is not None:
-                        elapsed_time = round(current_time - self.client.last_update, 3)
-                        max_response_time = round(theoretical_time, 3)
-                        
-                        if elapsed_time > max_response_time:
-                            logger.warning(f"Agent has not answered in time. Update took {elapsed_time} instead of max {max_response_time}")
 
-                        else:
-                            logger.debug(f"Agent answered in time. Update took {elapsed_time} instead of max {max_response_time}")
-                    
                     # Update the last update time and call update_agent with timeout monitoring
                     if hasattr(self.client, "agent") and self.client.agent is not None:
                         timeout_seconds = self.client.config.server_timeout_seconds
-                        self.client.last_update = current_time
                         
                         # Run agent update in a separate thread with timeout
                         with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
-                            # Submit update_agent task
-                            self.client.has_answered = False
+                            # Submit update_agent task and measure actual execution time
+                            start_time = time.time()
                             future = executor.submit(self.client.agent.update_agent)
                             
                             try:
                                 # Wait for the result with timeout
                                 future.result(timeout=timeout_seconds)
+                                # Calculate and log the actual execution time
+                                execution_time = round(time.time() - start_time, 3)
+
+                                from client.game_state import INITIAL_SPEED, SPEED_DECREMENT_COEFFICIENT
+                                train_speed = INITIAL_SPEED * SPEED_DECREMENT_COEFFICIENT ** len(self.client.trains[self.client.nickname]["wagons"])
+                                theoretical_time = 1.0 / train_speed
+                                max_response_time = round(theoretical_time, 3)
+
+                                if execution_time > max_response_time:
+                                    logger.warning(f"Agent has not answered in time. Update took {execution_time} instead of max {max_response_time}")
+                                
                             except concurrent.futures.TimeoutError:
                                 # The agent took too long to respond
                                 error_msg = f"Agent too slow! Execution exceeded timeout limit of {timeout_seconds}s"
@@ -71,9 +65,11 @@ class AgentThread(threading.Thread):
                                 logger.error(error_msg)
                                 self.display_error_and_exit(error_msg)
                     
-                    # Sleep for slightly less than theoretical_time to ensure we don't miss updates
-                    sleep_duration = 1 / self.client.REFERENCE_TICK_RATE
-                    time.sleep(sleep_duration)
+                    # Calculate sleep duration based on train speed
+                    # The original game calls move() when move_timer >= REFERENCE_TICK_RATE / speed
+                    # So we should update at a similar rate
+                    tick_interval = 1 / self.client.REFERENCE_TICK_RATE  # Time per tick
+                    time.sleep(tick_interval)  # Update at each tick to match the game's pace
                 else:
                     # Default sleep if we can't calculate based on train
                     time.sleep(0.05)

--- a/client/agent_thread.py
+++ b/client/agent_thread.py
@@ -1,0 +1,95 @@
+import threading
+import time
+import logging
+import sys
+import pygame
+import concurrent.futures
+
+
+logger = logging.getLogger("client.agent_thread")
+
+class AgentThread(threading.Thread):
+    """Thread responsible for calling update_agent() at regular intervals"""
+    
+    def __init__(self, client):
+        """Initialize the agent thread"""
+        super().__init__(daemon=True)  # Set as daemon so it exits when the main thread exits
+        self.client = client
+        self.running = True
+    
+    def run(self):
+        """Main thread loop to update the agent at appropriate intervals"""
+        logger.info("Starting agent thread")
+        
+        while self.running:
+            # Only update if the client is initialized, not dead, and has a train
+            if (self.client.is_initialized and 
+                not self.client.is_dead and 
+                self.client.nickname in self.client.trains):
+                
+                # Calculate the appropriate timing based on train speed
+                if len(self.client.trains) > 0 and self.client.nickname in self.client.trains:
+                    # Use the same formula as in GameState.handle_state_data
+                    from client.game_state import INITIAL_SPEED, SPEED_DECREMENT_COEFFICIENT
+                    train_speed = INITIAL_SPEED * SPEED_DECREMENT_COEFFICIENT ** len(self.client.trains[self.client.nickname]["wagons"])
+                    theoretical_time = 1.0 / train_speed
+                    
+                    # Check if agent is taking too long to respond
+                    current_time = time.time()
+                    if self.client.last_update is not None:
+                        elapsed_time = round(current_time - self.client.last_update, 3)
+                        max_response_time = round(theoretical_time, 3)
+                        
+                        if elapsed_time > max_response_time:
+                            logger.warning(f"Agent has not answered in time. Update took {elapsed_time} instead of max {max_response_time}")
+
+                        else:
+                            logger.debug(f"Agent answered in time. Update took {elapsed_time} instead of max {max_response_time}")
+                    
+                    # Update the last update time and call update_agent with timeout monitoring
+                    if hasattr(self.client, "agent") and self.client.agent is not None:
+                        timeout_seconds = self.client.config.server_timeout_seconds
+                        self.client.last_update = current_time
+                        
+                        # Run agent update in a separate thread with timeout
+                        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                            # Submit update_agent task
+                            self.client.has_answered = False
+                            future = executor.submit(self.client.agent.update_agent)
+                            
+                            try:
+                                # Wait for the result with timeout
+                                future.result(timeout=timeout_seconds)
+                            except concurrent.futures.TimeoutError:
+                                # The agent took too long to respond
+                                error_msg = f"Agent too slow! Execution exceeded timeout limit of {timeout_seconds}s"
+                                logger.error(error_msg)
+                                self.display_error_and_exit(error_msg)
+                            except Exception as e:
+                                # Other errors in the agent
+                                error_msg = f"Error in agent: {str(e)}"
+                                logger.error(error_msg)
+                                self.display_error_and_exit(error_msg)
+                    
+                    # Sleep for slightly less than theoretical_time to ensure we don't miss updates
+                    sleep_duration = 1 / self.client.REFERENCE_TICK_RATE
+                    time.sleep(sleep_duration)
+                else:
+                    # Default sleep if we can't calculate based on train
+                    time.sleep(0.05)
+            else:
+                # Sleep a bit longer if conditions aren't met
+                time.sleep(0.1)
+    
+    def stop(self):
+        """Stop the thread"""
+        self.running = False
+        
+    def display_error_and_exit(self, error_message):
+        """Display an error message and exit the game"""
+        logger.error(f"Forced game termination: {error_message}")
+        
+        self.client.network.disconnect(stop_client=True)
+        
+        # Stop the thread
+        self.stop()

--- a/client/client.py
+++ b/client/client.py
@@ -153,8 +153,6 @@ class Client:
 
         self.ping_response_received = False
         self.server_disconnected = False
-
-        self.last_update = None
         
         # Initialiser et démarrer le thread d'agent si on est en mode AGENT
         self.agent_thread = None

--- a/client/client.py
+++ b/client/client.py
@@ -10,6 +10,7 @@ from client.network import NetworkManager
 from client.renderer import Renderer
 from client.event_handler import EventHandler
 from client.game_state import GameState
+from client.agent_thread import AgentThread
 
 from common.config import Config
 from common.client_config import GameMode
@@ -75,6 +76,8 @@ class Client:
         self.cell_size = 0
         self.game_width = 200  # Initial game area width
         self.game_height = 200  # Initial game area height
+
+        self.REFERENCE_TICK_RATE = REFERENCE_TICK_RATE
 
         # Space between game area and leaderboard
         self.game_screen_padding = 20
@@ -150,6 +153,15 @@ class Client:
 
         self.ping_response_received = False
         self.server_disconnected = False
+
+        self.last_update = None
+        
+        # Initialiser et démarrer le thread d'agent si on est en mode AGENT
+        self.agent_thread = None
+        if self.game_mode == GameMode.AGENT and self.agent is not None:
+            self.agent_thread = AgentThread(self)
+            self.agent_thread.start()
+            logger.info("Agent thread started")
 
     def update_game_window_size(self, width=None, height=None):
         """Schedule window size update to be done in main thread"""
@@ -234,7 +246,7 @@ class Client:
         clock = pygame.time.Clock()
         while self.running:
             self.update()
-            clock.tick(REFERENCE_TICK_RATE)
+            clock.tick(self.REFERENCE_TICK_RATE)
 
         # Close connection
         self.network.disconnect()

--- a/client/game_state.py
+++ b/client/game_state.py
@@ -116,16 +116,6 @@ class GameState:
                 self.client.agent.game_height = self.client.game_height
             if self.client.agent.delivery_zone is None:
                 self.client.agent.delivery_zone = self.client.delivery_zone
-            
-            # Check if the train is in the client's stored trains collection
-            train_exists = self.client.nickname in self.client.trains
-
-            # Le thread gère indépendamment l'appel à update_agent() au bon rythme
-            # et les vérifications de temps de réponse
-            if self.client.last_update is None and not self.client.is_dead and train_exists:
-                # Initialize the last update time if it's not set
-                # Seulement pour la première initialisation
-                self.client.last_update = time.time()
 
     def handle_leaderboard_data(self, data):
         """Handle leaderboard data received from the server"""

--- a/client/game_state.py
+++ b/client/game_state.py
@@ -4,9 +4,10 @@ import time
 
 from common.client_config import GameMode
 
-
 logger = logging.getLogger("client.game_state")
 
+INITIAL_SPEED = 10
+SPEED_DECREMENT_COEFFICIENT = 0.95  # Speed reduction coefficient for each wagon
 
 class GameState:
     """Class responsible for managing the game state"""
@@ -18,7 +19,6 @@ class GameState:
 
     def handle_state_data(self, data):
         """Handle game state data received from the server"""
-
         if not isinstance(data, dict):
             logger.warning("Received non-dictionary state data: " + str(data))
             return
@@ -119,9 +119,13 @@ class GameState:
             
             # Check if the train is in the client's stored trains collection
             train_exists = self.client.nickname in self.client.trains
-                            
-            if not self.client.is_dead and train_exists:
-                self.client.agent.update_agent()
+
+            # Le thread gère indépendamment l'appel à update_agent() au bon rythme
+            # et les vérifications de temps de réponse
+            if self.client.last_update is None and not self.client.is_dead and train_exists:
+                # Initialize the last update time if it's not set
+                # Seulement pour la première initialisation
+                self.client.last_update = time.time()
 
     def handle_leaderboard_data(self, data):
         """Handle leaderboard data received from the server"""

--- a/client/network.py
+++ b/client/network.py
@@ -68,7 +68,7 @@ class NetworkManager:
             # On laisse le client gérer l'affichage du message et la fermeture
             logger.warning("Server disconnection detected. Stopping client.")
 
-        if self.socket:
+        if self.socket and self.socket is not None:
             # Envoyer un message à nous-même pour débloquer le recvfrom
             if hasattr(self, "server_addr"):
                 try:


### PR DESCRIPTION
Now when an agent takes more than 2 seconds to return a move the client closes with an error.
If the agent takes more than the required amount of time between two moves (defined from the "speed" from train.py), the game displays a warning.

The equivalent is needed for the sever/bot part