### PR TITLE
Using a thread for get_move()

### DIFF
--- a/client/client.py
+++ b/client/client.py
@@ -146,7 +146,7 @@ class Client:
 
                 # Add parent directory to Python path to allow importing agents package
                 module = importlib.import_module(module_path)
-                self.agent = module.Agent(self.nickname, self.network)
+                self.agent = module.Agent(self.nickname, self.network, timeout=1/REFERENCE_TICK_RATE)
 
         self.ping_response_received = False
         self.server_disconnected = False

--- a/client/network.py
+++ b/client/network.py
@@ -64,17 +64,12 @@ class NetworkManager:
         if stop_client:
             self.client.running = False
 
-            # Afficher un message d'erreur si la déconnexion est due à un timeout du serveur
-            # On laisse le client gérer l'affichage du message et la fermeture
             logger.warning("Server disconnection detected. Stopping client.")
 
-        if self.socket:
-            # Envoyer un message à nous-même pour débloquer le recvfrom
+        if self.socket and self.socket is not None:
             if hasattr(self, "server_addr"):
                 try:
-                    # Obtenir l'adresse locale du socket
                     local_addr = self.socket.getsockname()
-                    # Envoyer un message vide à nous-même pour débloquer le recvfrom
                     dummy_socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
                     dummy_socket.sendto(b"", local_addr)
                     dummy_socket.close()

--- a/common/base_agent.py
+++ b/common/base_agent.py
@@ -1,15 +1,41 @@
 import logging
+import threading
+import ctypes
 from client.network import NetworkManager
 from common import move
-import concurrent.futures
 from common.constants import REFERENCE_TICK_RATE
+
+
+def _terminate_thread(thread):
+    """Terminate a thread forcefully.
+    
+    Args:
+        thread: The thread to terminate
+    """
+    if not thread.is_alive():
+        return
+        
+    # Get thread identifier
+    tid = ctypes.c_long(thread.ident)
+    
+    # Raise exception in the thread
+    exc = ctypes.py_object(SystemExit)
+    res = ctypes.pythonapi.PyThreadState_SetAsyncExc(tid, exc)
+    
+    if res == 0:
+        # Thread ID not found
+        raise ValueError("Invalid thread ID")
+    elif res > 1:
+        # If multiple threads were affected, clean up and raise error
+        ctypes.pythonapi.PyThreadState_SetAsyncExc(tid, None)
+        raise SystemError("PyThreadState_SetAsyncExc failed")
 
 
 class BaseAgent:
     """Base class for all agents, enforcing the implementation of get_move()."""
 
     def __init__(
-        self, nickname: str, network: NetworkManager, logger: str = "client.agent"
+        self, nickname: str, network: NetworkManager, logger: str = "client.agent", timeout: float = 1/REFERENCE_TICK_RATE
     ):
         """
         Initialize the base agent. Not supposed to be modified.
@@ -31,6 +57,7 @@ class BaseAgent:
         self.logger.setLevel(logging.DEBUG)
         self.nickname = nickname
         self.network = network
+        self.timeout = timeout
 
         # Game parameters, regularly updated by the client in handle_state_data() (see game_state.py)
         self.cell_size = None
@@ -41,12 +68,23 @@ class BaseAgent:
         self.delivery_zone = None
         self.best_scores = None
 
+    def _run_get_move(self):
+        """
+        Wrapper method to call get_move() in a separate thread.
+        Stores the result in self._move_result.
+        """
+        try:
+            self._move_result = self.get_move()
+        except Exception as e:
+            self.logger.error(f"get_move() raised an exception: {e}")
+            self._move_result = None
+
     def get_move(self):
         """
         Abstract method to be implemented by subclasses.
         Must return a valid move.Move.
         """
-        pass
+        raise NotImplementedError("Subclasses must implement this method")
 
     def update_agent(self):
         """
@@ -54,19 +92,39 @@ class BaseAgent:
 
         Returning from this method without doing anything will cause the train to continue moving forward.
         """
-        with concurrent.futures.ThreadPoolExecutor() as executor:
-            future = executor.submit(self.get_move)
+            
+        # Create a thread dedicated to get_move() that we can control directly
+        worker_thread = threading.Thread(target=self._run_get_move)
+        worker_thread.daemon = True  # The thread will close with the main program
+        
+        # Variable to store the result
+        self._move_result = None
+        
+        # Start the thread
+        worker_thread.start()
+        
+        # Wait for the thread to finish or timeout
+        worker_thread.join(self.timeout)
+        
+        # If the thread is still running after the timeout
+        if worker_thread.is_alive():
+            # Terminate it forcefully
             try:
-                new_direction = future.result(timeout=1/REFERENCE_TICK_RATE)
-            except concurrent.futures.TimeoutError:
-                # The agent took too long to respond
-                error_msg = f"Agent {self.nickname} too slow! Execution exceeded timeout limit of 1/{REFERENCE_TICK_RATE}s"
+                _terminate_thread(worker_thread)
+                error_msg = f"Agent {self.nickname} too slow. Execution exceeded timeout limit of {round(self.timeout, 3)}s"
                 self.logger.error(error_msg)
                 return
             except Exception as e:
-                self.logger.error(f"get_move() raised an exception: {e}")
+                self.logger.error(f"Failed to terminate agent thread: {e}")
                 return
-            
+        
+        # If we arrive here, the thread has finished normally
+        if self._move_result is None:
+            # get_move() has finished but did not return a valid result
+            return
+        
+        new_direction = self._move_result
+        
         if new_direction not in move.Move:
             self.logger.error("get_move() did not return a valid move!")
             return

--- a/server/ai_client.py
+++ b/server/ai_client.py
@@ -3,8 +3,6 @@ AI client for the game "I Like Trains"
 This module provides an AI client that can control trains on the server side
 """
 
-import threading
-import time
 import logging
 import json
 from server.passenger import Passenger
@@ -98,7 +96,7 @@ class AIClient:
             logger.info(f"Importing module: {module_path}")
 
             module = importlib.import_module(module_path)
-            self.agent = module.Agent(nickname, self.network, logger="server.ai_agent")
+            self.agent = module.Agent(nickname, self.network, logger="server.ai_agent", timeout=1 / self.room.config.tick_rate)
             logger.info(f"AI agent {nickname} initialized using {ai_agent_file_name}")
 
         except ImportError as e:


### PR DESCRIPTION
To be able to solve the problem of having a call to get_move() taking forever (annoying especially in grading mode because the whole game is then frozen) I had to remove concurrent.futures and use a thread calling get_move() in base_agent(). It is practical because then we can kill the thread after the timeout and the whole game is still updated on time. Same thing with grading_mode, the game is compiled instantly.In grading mode the thread get_move() is killed every time the timeout is reached and in the end the score is 0.
Fixing #193 